### PR TITLE
fix: adjust initial vehicle fetching to only fail if no vehicles load

### DIFF
--- a/custom_components/uconnect/coordinator.py
+++ b/custom_components/uconnect/coordinator.py
@@ -82,7 +82,7 @@ class UconnectDataUpdateCoordinator(DataUpdateCoordinator):
             await self.hass.async_add_executor_job(self.client.refresh)
         except Exception as err:
             # On first run (no cached data), re-raise to signal setup failure
-            if self.data is None:
+            if self.data is None and not self.client.vehicles:
                 _LOGGER.error("Initial data fetch failed: %s", err)
                 raise
             # On subsequent runs, log and fall back to cached data


### PR DESCRIPTION
If a user has multiple vehicles on their account and atleast 1 vehicles fetches successfully, we no longer abort integration setup. Fixes #93 