### PR TITLE
fix: skip internal keys when resolving coordinator from device

### DIFF
--- a/custom_components/uconnect/services.py
+++ b/custom_components/uconnect/services.py
@@ -182,7 +182,7 @@ def async_unload_services(hass) -> None:
 
 
 def _get_vin_from_device(hass: HomeAssistant, call: ServiceCall) -> str:
-    coordinators = list(hass.data[DOMAIN].keys())
+    coordinators = [k for k in hass.data[DOMAIN] if not k.startswith("_")]
 
     if len(coordinators) == 1:
         coordinator: UconnectDataUpdateCoordinator = hass.data[DOMAIN][coordinators[0]]
@@ -204,7 +204,7 @@ def _get_vin_from_device(hass: HomeAssistant, call: ServiceCall) -> str:
 def _get_coordinator_from_device(
     hass: HomeAssistant, call: ServiceCall
 ) -> UconnectDataUpdateCoordinator:
-    coordinators = list(hass.data[DOMAIN].keys())
+    coordinators = [k for k in hass.data[DOMAIN] if not k.startswith("_")]
 
     if len(coordinators) == 1:
         return hass.data[DOMAIN][coordinators[0]]


### PR DESCRIPTION
hass.data[DOMAIN] contains internal keys prefixed with "_" (e.g. _frontend_cards_setup, _frontend_cards_resource_id) alongside the coordinator entries. Both _get_coordinator_from_device and _get_vin_from_device counted these when checking if only one account is configured, causing the single-account shortcut to never trigger.

This caused a KeyError on device_id when calling services (e.g. deep_refresh) without explicitly passing a device_id, as the code fell through to call.data[ATTR_DEVICE_ID] which is not required for single-account setups.

Fix mirrors the filter already used in __init__.py: exclude keys starting with "_" when building the coordinator list.

Fixes #97