### PR TITLE
Fix deprecation of `TrackerEntity`

### DIFF
--- a/custom_components/uconnect/device_tracker.py
+++ b/custom_components/uconnect/device_tracker.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from py_uconnect.client import Vehicle
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -53,10 +52,6 @@ class UconnectTracker(TrackerEntity, UconnectEntity):
         if self.vehicle.location is None:
             return None
         return self.vehicle.location.longitude
-
-    @property
-    def battery_level(self):
-        return self.vehicle.state_of_charge
 
     @property
     def source_type(self):


### PR DESCRIPTION
Followed steps in https://developers.home-assistant.io/blog/2026/06/15/device-tracker-changes

- Remove `battery_level`
- Update import for `TrackerEntity`

Removal is scheduled for 2027.7. Closes #106