### PR TITLE
Fix vehicle image HTTP 403 by sending a browser User-Agent

### DIFF
--- a/custom_components/uconnect/image.py
+++ b/custom_components/uconnect/image.py
@@ -130,8 +130,16 @@ class UconnectVehicleImage(UconnectEntity, ImageEntity):
         """Download image from URL."""
         try:
             session = async_get_clientsession(self.hass)
+            headers = {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/126.0.0.0 Safari/537.36"
+                ),
+                "Accept": "image/avif,image/webp,image/png,image/*,*/*",
+            }
             async with session.get(
-                url, timeout=aiohttp.ClientTimeout(total=30)
+                url, headers=headers, timeout=aiohttp.ClientTimeout(total=30)
             ) as resp:
                 if resp.status != 200:
                     _LOGGER.warning(


### PR DESCRIPTION
## Problem
The image entity logs `Failed to fetch vehicle image: HTTP 403` and never loads. `_fetch_image()` downloads the `preciseImageURL` with no headers, so aiohttp's default Python User-Agent is used. The image CDN (e.g. `www.ramtrucks.com`, fronted by Akamai) blocks that UA with a 403 "Access Denied" (`errors.edgesuite.net`). This is **not** a Uconnect auth issue.

## Evidence
Reproduced with curl against a real `preciseImageURL`:

| User-Agent | Result |
| --- | --- |
| curl / Python / aiohttp default | `403` (Akamai Access Denied) | | Browser (Chrome) UA | `200 image/png` (served by `Server: Akamai Image Manager`) |

Same URL, only the User-Agent differs.

## Fix
Send a browser-like `User-Agent` (and `Accept: image/*`) on the image download.

Verified end-to-end on a Ram 1500 (Canada): the 403 is gone and the image entity populates.

Fixes #116